### PR TITLE
Fix: temporarily remove upstream exclusive inclusions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,14 @@ jobs:
           repository: v2fly/domain-list-community
           path: domain-list-community
 
+      - name: Temporarily remove upstream exclusive inclusions
+        if: ${{ env.NeedToSync }}
+        run: |
+          cd domain-list-community/data || exit 1
+          for cnlist in ./*-cn; do
+            sed -i 's/ @-!cn//' $cnlist
+          done
+
       - name: Append attribute rules
         if: ${{ env.NeedToSync }}
         run: |


### PR DESCRIPTION
fix https://github.com/Loyalsoldier/domain-list-custom/issues/135

CI passed: https://github.com/saldry/domain-list-custom/actions. You can find `domain:qq.com` in https://github.com/saldry/domain-list-custom/blob/release/geolocation-cn.txt