### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
       - master
     paths-ignore:
       - "**/README.md"
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Loyalsoldier/domain-list-custom/security/code-scanning/1](https://github.com/Loyalsoldier/domain-list-custom/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs (here, just `build`) inherit it.  
For this workflow, `contents: write` is required because it pushes to a branch and creates/releases assets in the same repository. No extra scopes are clearly needed from the shown snippet.

Edit `.github/workflows/build.yml` near the top-level keys, inserting:

- `permissions:`
  - `contents: write`

Place it after the `on:` block and before `jobs:` (or anywhere at root level), preserving existing behavior while enforcing explicit token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
